### PR TITLE
Automatically select assignment or task after creation

### DIFF
--- a/packages/fe-shared/utils/misc.js
+++ b/packages/fe-shared/utils/misc.js
@@ -1,0 +1,6 @@
+export function noProp(fn) {
+    return (event, ...otherProps) => {
+        event.stopPropagation();
+        fn(event, ...otherProps);
+    };
+}

--- a/services/frontend/src/components/assignments/assignment-cell.js
+++ b/services/frontend/src/components/assignments/assignment-cell.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { IconButton, Tooltip } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { getAssignmentsSelectors, updateAssignment, updateAssignmentLocal } from '@logan/fe-shared/store/assignments';
+import { noProp } from '@logan/fe-shared/utils/misc';
 import Typography from '../shared/typography';
 import styles from './assignment-cell.module.scss';
 
@@ -57,7 +58,7 @@ class AssignmentCell extends React.Component {
                         <div className="actions">
                             {this.props.onDelete && (
                                 <Tooltip title="Delete">
-                                    <IconButton size="small" className={styles.action} onClick={this.deleted}>
+                                    <IconButton size="small" className={styles.action} onClick={noProp(this.deleted)}>
                                         <DeleteIcon fontSize="small" color="error" />
                                     </IconButton>
                                 </Tooltip>

--- a/services/frontend/src/components/assignments/assignment-modal.js
+++ b/services/frontend/src/components/assignments/assignment-modal.js
@@ -74,10 +74,11 @@ class AssignmentModal extends React.Component {
     async createAssignment() {
         this.setState({ isCreating: true });
         const id = setTimeout(() => this.setState({ showLoader: true }), 500);
-        await this.props.createAssignment(this.state.assignment);
+        const result = await this.props.createAssignment(this.state.assignment);
+        const newAssignment = result.payload;
         clearTimeout(id);
         this.setState({ showLoader: false, isCreating: false });
-        this.props.onClose();
+        this.props.onClose({ newAssignment });
     }
 
     handleChange(prop, e) {

--- a/services/frontend/src/components/assignments/assignments-list.js
+++ b/services/frontend/src/components/assignments/assignments-list.js
@@ -76,17 +76,19 @@ class AssignmentsList extends React.Component {
 
     didDeleteAssignment(assignment) {
         this.props.deleteAssignment(assignment);
-        // TODO: Select next assignment
-        this.setState(() => ({ selectedAid: undefined }));
-        this.props.onAssignmentSelected(undefined);
+        this.didSelectAssignment(undefined);
     }
 
     openNewAssignmentModal() {
         this.setState({ newAssignmentModalOpen: true });
     }
 
-    closeNewAssignmentModal() {
+    closeNewAssignmentModal({ newAssignment }) {
         this.setState({ newAssignmentModalOpen: false });
+
+        if (newAssignment && newAssignment.aid) {
+            this.didSelectAssignment(newAssignment.aid);
+        }
     }
 
     _shouldShowAssignment(assignment) {

--- a/services/frontend/src/components/assignments/assignments-page.js
+++ b/services/frontend/src/components/assignments/assignments-page.js
@@ -19,6 +19,8 @@ class AssignmentsPage extends React.Component {
     }
 
     didSelectAssignment(aid) {
+        console.log(aid);
+        console.trace();
         this.setState({ selectedAid: aid });
     }
 

--- a/services/frontend/src/components/schedule/term-editor.js
+++ b/services/frontend/src/components/schedule/term-editor.js
@@ -11,6 +11,7 @@ import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import AddIcon from '@material-ui/icons/AddCircleOutline';
 import DeleteIcon from '@material-ui/icons/Delete';
 import Editor from '@logan/fe-shared/components/editor';
+import { noProp } from '@logan/fe-shared/utils/misc';
 import {
     getScheduleSelectors,
     updateTerm,
@@ -34,13 +35,6 @@ const {
     dayjs,
     constants: { DB_DATE_FORMAT },
 } = dateUtils;
-
-function noProp(fn) {
-    return (event, ...otherProps) => {
-        event.stopPropagation();
-        fn(event, ...otherProps);
-    };
-}
 
 class TermEditor extends Editor {
     constructor(props) {

--- a/services/frontend/src/components/tasks/task-cell.js
+++ b/services/frontend/src/components/tasks/task-cell.js
@@ -11,6 +11,7 @@ import { dateUtils } from '@logan/core';
 import { getTasksSelectors, updateTask, updateTaskLocal, setShouldGoToTask } from '@logan/fe-shared/store/tasks';
 import { getScheduleSelectors } from '@logan/fe-shared/store/schedule';
 import { getAssignmentsSelectors } from '@logan/fe-shared/store/assignments';
+import { noProp } from '@logan/fe-shared/utils/misc';
 import { colorForValue } from '../shared/displays/priority-constants';
 import PriorityDisplay from '../shared/displays/priority-display';
 import Checkbox from '../shared/controls/checkbox';
@@ -111,7 +112,7 @@ class TaskCell extends React.Component {
                     className={styles.checkbox}
                     cid={_.get(this.state.task, 'cid')}
                     checked={_.get(this.state, 'task.complete', false)}
-                    onChange={this.toggleCompletion}
+                    onChange={noProp(this.toggleCompletion)}
                 />
                 <div className={styles.taskContent}>
                     <Typography>{task.title}</Typography>
@@ -134,7 +135,11 @@ class TaskCell extends React.Component {
                             <PriorityDisplay priority={task.priority} className={styles.priorityDisplay} />
                             <div className="actions">
                                 {shouldShowMoveToToday && (
-                                    <Tooltip title="Move to today" className={styles.action} onClick={this.moveToToday}>
+                                    <Tooltip
+                                        title="Move to today"
+                                        className={styles.action}
+                                        onClick={noProp(this.moveToToday)}
+                                    >
                                         <IconButton size="small">
                                             <TodayIcon fontSize="small" />
                                         </IconButton>
@@ -142,7 +147,11 @@ class TaskCell extends React.Component {
                                 )}
                                 {this.props.onDelete && (
                                     <Tooltip title="Delete">
-                                        <IconButton size="small" className={styles.action} onClick={this.deleted}>
+                                        <IconButton
+                                            size="small"
+                                            className={styles.action}
+                                            onClick={noProp(this.deleted)}
+                                        >
                                             <DeleteIcon fontSize="small" color="error" />
                                         </IconButton>
                                     </Tooltip>

--- a/services/frontend/src/components/tasks/task-modal.js
+++ b/services/frontend/src/components/tasks/task-modal.js
@@ -87,10 +87,11 @@ class TaskModal extends React.Component {
     async createTask() {
         this.setState({ isCreating: true });
         const id = setTimeout(() => this.setState({ showLoader: true }), 500);
-        await this.props.createTask(this.state.task);
+        const result = await this.props.createTask(this.state.task);
+        const newTask = result.payload;
         clearTimeout(id);
         this.setState({ showLoader: false, isCreating: false });
-        this.props.onClose();
+        this.props.onClose({ newTask });
     }
 
     handleChange(prop, e) {

--- a/services/frontend/src/components/tasks/tasks-list.js
+++ b/services/frontend/src/components/tasks/tasks-list.js
@@ -60,17 +60,19 @@ class TasksList extends React.Component {
 
     didDeleteTask(task) {
         this.props.deleteTask(task);
-        // TODO: Select next task
-        this.setState(() => ({ selectedTid: undefined }));
-        this.props.onTaskSelected(undefined);
+        this.didSelectTask(undefined);
     }
 
     openCreateModal() {
         this.setState({ newTaskModalOpen: true });
     }
 
-    closeCreateModal() {
+    closeCreateModal({ newTask }) {
         this.setState({ newTaskModalOpen: false });
+
+        if (newTask && newTask.tid) {
+            this.didSelectTask(newTask.tid);
+        }
     }
 
     toggleCompletedTasks(e) {


### PR DESCRIPTION
When the user creates a new task or assignment, the onClose handler for the modal will pass the created object, so it can be automatically selected